### PR TITLE
Fix Map Room mobile rendering (lg:hidden nested bug)

### DIFF
--- a/src/components/flow/FeedTable.tsx
+++ b/src/components/flow/FeedTable.tsx
@@ -303,9 +303,10 @@ function FeedGroupRows({
                     )}
                   </div>
                 </div>
+              </div>
 
-                {/* Mobile layout */}
-                <div className="lg:hidden p-3 space-y-2">
+              {/* Mobile layout */}
+              <div className="lg:hidden p-3 space-y-2">
                   {/* Row 1: label + status + expand */}
                   <div className="flex items-center justify-between gap-3">
                     <div className="flex items-center gap-2 min-w-0 flex-1">
@@ -437,7 +438,6 @@ function FeedGroupRows({
                     </div>
                   </div>
                 </div>
-              </div>
             </div>
 
             {/* Expanded details box */}


### PR DESCRIPTION
Fixes a breakpoint nesting issue that caused Map Room on mobile to render only borders (thin white lines). The lg:hidden mobile layout is now a sibling of the hidden lg:block desktop layout.