### PR TITLE
Fix: Compound claim button should not close modal

### DIFF
--- a/src/components/AnchorClaimAllModal.tsx
+++ b/src/components/AnchorClaimAllModal.tsx
@@ -249,7 +249,6 @@ export const AnchorClaimAllModal = ({
  <button
  onClick={() => {
  onCompound(selectedPoolsArray);
- onClose();
  }}
  disabled={isLoading || selectedPoolsArray.length === 0}
  className="w-full p-4 text-left bg-white border-2 border-[#1E4775] hover:bg-[#1E4775]/5 transition-colors flex items-center justify-between group disabled:opacity-50 disabled:cursor-not-allowed"

--- a/src/components/AnchorClaimMarketModal.tsx
+++ b/src/components/AnchorClaimMarketModal.tsx
@@ -100,7 +100,6 @@ export const AnchorClaimMarketModal = ({
  <button
  onClick={() => {
  onCompound();
- onClose();
  }}
  disabled={isLoading}
  className={`px-4 py-2 text-sm font-medium transition-colors rounded-full ${


### PR DESCRIPTION
## Fix
The Compound claim buttons were calling onClose() immediately after onCompound(), which could cancel the compound flow and look like the button does nothing.

## Changes
- src/components/AnchorClaimAllModal.tsx: removed immediate onClose() after compound
- src/components/AnchorClaimMarketModal.tsx: removed immediate onClose() after compound

## Testing
- Click Compound: modal stays open and the compound flow can proceed.