### PR TITLE
Fix: show stability pool positions per market + pool

### DIFF
--- a/src/app/anchor/page.tsx
+++ b/src/app/anchor/page.tsx
@@ -6653,47 +6653,79 @@ export default function AnchorPage() {
                                     Your Positions
                                   </div>
                                   <div className="space-y-2">
-                                    {/* Collateral Pool Deposit - aggregated */}
-                                    {totalCollateralPoolDeposit > 0n && (
-                                      <div className="flex justify-between items-center text-xs">
-                                        <span className="text-[#1E4775]/70">
-                                          Collateral Pool:
-                                        </span>
-                                        <div className="text-right">
-                                          <div className="font-semibold text-[#1E4775] font-mono">
-                                            {formatCompactUSD(
-                                              totalCollateralPoolDepositUSD
-                                            )}
-                                          </div>
-                                          <div className="text-[10px] text-[#1E4775]/50 font-mono">
-                                            {formatToken(
-                                              totalCollateralPoolDeposit
-                                            )}{" "}
-                                            {haSymbol}
-                                          </div>
-                                        </div>
-                                      </div>
-                                    )}
+                                    {(() => {
+                                      // Show one row per (marketId, poolType) so we don't collapse positions
+                                      // across different markets in the same ha-token group.
+                                      const hasMultipleMarkets =
+                                        activeMarketsData.length > 1;
 
-                                    {/* Sail Pool Deposit - aggregated */}
-                                    {totalSailPoolDeposit > 0n && (
-                                      <div className="flex justify-between items-center text-xs">
-                                        <span className="text-[#1E4775]/70">
-                                          Sail Pool:
-                                        </span>
-                                        <div className="text-right">
-                                          <div className="font-semibold text-[#1E4775] font-mono">
-                                            {formatCompactUSD(
-                                              totalSailPoolDepositUSD
-                                            )}
-                                          </div>
-                                          <div className="text-[10px] text-[#1E4775]/50 font-mono">
-                                            {formatToken(totalSailPoolDeposit)}{" "}
-                                            {haSymbol}
+                                      const rows: Array<{
+                                        key: string;
+                                        label: string;
+                                        deposit: bigint;
+                                        depositUSD: number;
+                                      }> = [];
+
+                                      activeMarketsData.forEach((md) => {
+                                        const marketLabel =
+                                          md.market?.collateral?.symbol ||
+                                          md.marketId;
+
+                                        if (
+                                          md.collateralPoolDeposit &&
+                                          md.collateralPoolDeposit > 0n
+                                        ) {
+                                          rows.push({
+                                            key: `${md.marketId}-collateral`,
+                                            label: `Collateral Pool${
+                                              hasMultipleMarkets
+                                                ? ` (${marketLabel})`
+                                                : ""
+                                            }`,
+                                            deposit: md.collateralPoolDeposit,
+                                            depositUSD:
+                                              md.collateralPoolDepositUSD || 0,
+                                          });
+                                        }
+
+                                        if (
+                                          md.sailPoolDeposit &&
+                                          md.sailPoolDeposit > 0n
+                                        ) {
+                                          rows.push({
+                                            key: `${md.marketId}-sail`,
+                                            label: `Sail Pool${
+                                              hasMultipleMarkets
+                                                ? ` (${marketLabel})`
+                                                : ""
+                                            }`,
+                                            deposit: md.sailPoolDeposit,
+                                            depositUSD: md.sailPoolDepositUSD || 0,
+                                          });
+                                        }
+                                      });
+
+                                      if (rows.length === 0) return null;
+
+                                      return rows.map((r) => (
+                                        <div
+                                          key={r.key}
+                                          className="flex justify-between items-center text-xs"
+                                        >
+                                          <span className="text-[#1E4775]/70">
+                                            {r.label}:
+                                          </span>
+                                          <div className="text-right">
+                                            <div className="font-semibold text-[#1E4775] font-mono">
+                                              {formatCompactUSD(r.depositUSD)}
+                                            </div>
+                                            <div className="text-[10px] text-[#1E4775]/50 font-mono">
+                                              {formatToken(r.deposit)} {haSymbol}
+                                            </div>
                                           </div>
                                         </div>
-                                      </div>
-                                    )}
+                                      ));
+                                    })()}
                                   </div>
                                 </div>
                               )}

--- a/src/app/transparency/page.tsx
+++ b/src/app/transparency/page.tsx
@@ -39,6 +39,7 @@ import { useReadContract, useAccount } from "wagmi";
 import { minterABI } from "@/abis/minter";
 import Image from "next/image";
 import { useAllStabilityPoolRewards } from "@/hooks/useAllStabilityPoolRewards";
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 
 function formatUSD(value: number | undefined): string {
  if (value === undefined || !Number.isFinite(value)) return "-";
@@ -513,6 +514,55 @@ function MarketCard({
  100
  : 0;
 
+  // Calculate distribution for pie chart: Anchor Supply (3 parts) + Sail Supply
+  const distributionData = useMemo(() => {
+    const anchorSupply = market.peggedTokenBalance; // Total haToken supply
+    const sailSupply = market.leveragedTokenBalance; // Total Sail token supply
+    const collateralPoolTVL = pools.find(p => p.type === "collateral")?.tvl || 0n;
+    const sailPoolTVL = pools.find(p => p.type === "leveraged")?.tvl || 0n;
+    
+    // Anchor Supply is divided into 3 parts:
+    const anchorNotDeposited = anchorSupply > (collateralPoolTVL + sailPoolTVL) 
+      ? anchorSupply - collateralPoolTVL - sailPoolTVL 
+      : 0n;
+
+    const data = [];
+    
+    // Anchor Supply parts (3 sections)
+    if (anchorNotDeposited > 0n) {
+      data.push({
+        name: "Not Deposited",
+        value: Number(anchorNotDeposited) / 1e18,
+        rawValue: anchorNotDeposited,
+      });
+    }
+    if (collateralPoolTVL > 0n) {
+      data.push({
+        name: "Collateral Pool",
+        value: Number(collateralPoolTVL) / 1e18,
+        rawValue: collateralPoolTVL,
+      });
+    }
+    if (sailPoolTVL > 0n) {
+      data.push({
+        name: "Sail Pool",
+        value: Number(sailPoolTVL) / 1e18,
+        rawValue: sailPoolTVL,
+      });
+    }
+    
+    // Sail Supply (as separate slice)
+    if (sailSupply > 0n) {
+      data.push({
+        name: "Sail Supply",
+        value: Number(sailSupply) / 1e18,
+        rawValue: sailSupply,
+      });
+    }
+
+    return data;
+  }, [market.peggedTokenBalance, market.leveragedTokenBalance, pools]);
+
  return (
  <div className="overflow-hidden">
  {/* Market Bar */}
@@ -763,11 +813,80 @@ function MarketCard({
  {formatTokenBalanceMax2Decimals(market.leveragedTokenBalance)}
  </div>
  </div>
- </div>
- </div>
- </div>
+    </div>
+    </div>
 
- {/* Stability Pools */}
+    {/* Distribution Pie Chart */}
+    {distributionData.length > 0 && (
+      <div className="mt-2">
+        <h5 className="text-[#1E4775] font-semibold text-[10px] uppercase tracking-wider mb-1.5">
+          Supply Distribution
+        </h5>
+        <div className="w-full" style={{ height: "180px" }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={distributionData}
+                cx="50%"
+                cy="50%"
+                labelLine={false}
+                label={false}
+                outerRadius={65}
+                fill="#8884d8"
+                dataKey="value"
+              >
+                {distributionData.map((entry, index) => {
+                  let color = "#1E4775"; // harbor-blue (default)
+                  if (entry.name === "Not Deposited") {
+                    color = "#1E4775"; // harbor-blue
+                  } else if (entry.name === "Collateral Pool") {
+                    color = "#B8EBD5"; // harbor-mint (seafoam green)
+                  } else if (entry.name === "Sail Pool") {
+                    color = "#FF8A7A"; // harbor-coral (pearl orange)
+                  } else if (entry.name === "Sail Supply") {
+                    color = "#FCD34D"; // yellow sun
+                  }
+                  return <Cell key={`cell-${index}`} fill={color} stroke="#1E4775" strokeWidth={entry.name === "Sail Pool" ? 0 : 0} />;
+                })}
+              </Pie>
+              <Tooltip 
+                formatter={(value: number, name: string, props: any) => {
+                  const total = distributionData.reduce((sum, item) => sum + item.value, 0);
+                  const percent = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
+                  return [
+                    `${percent}%`,
+                    name
+                  ];
+                }}
+              />
+              <Legend 
+                wrapperStyle={{ 
+                  fontSize: '9px', 
+                  paddingTop: '8px',
+                  paddingBottom: '8px',
+                  paddingLeft: '8px',
+                  paddingRight: '8px',
+                  backgroundColor: 'rgba(30, 71, 117, 0.05)', // #1E4775/5
+                  borderRadius: '4px',
+                  marginTop: '8px',
+                  display: 'flex',
+                  justifyContent: 'center',
+                  flexWrap: 'nowrap',
+                  gap: '16px',
+                  overflow: 'hidden'
+                }}
+                layout="horizontal"
+                iconType="circle"
+                formatter={(value: string) => value}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    )}
+  </div>
+
+  {/* Stability Pools */}
  <div className="bg-white p-2.5 space-y-2 lg:col-span-2">
  <h4 className="text-[#1E4775] font-semibold text-xs uppercase tracking-wider mb-2">
  Stability Pools
@@ -855,6 +974,211 @@ function MarketCard({
  </div>
  );
  })}
+
+ {/* Anchor Supply TVL Row with Bar Visualization */}
+ <div className="space-y-2 mt-2 pt-2 border-t border-[#1E4775]/10">
+  <div className="flex flex-col gap-2">
+   <div className="flex items-center gap-2">
+    <span className="text-[#1E4775] font-semibold text-[10px] w-12">
+     Anchor supply
+    </span>
+    <div className="grid grid-cols-5 gap-1.5 text-xs flex-1">
+     {(() => {
+      const anchorSupply = market.peggedTokenBalance;
+      const collateralPoolTVL = pools.find(p => p.type === "collateral")?.tvl || 0n;
+      const sailPoolTVL = pools.find(p => p.type === "leveraged")?.tvl || 0n;
+      const anchorNotDeposited = anchorSupply > (collateralPoolTVL + sailPoolTVL) 
+        ? anchorSupply - collateralPoolTVL - sailPoolTVL 
+        : 0n;
+      
+      const anchorSupplyNum = Number(anchorSupply) / 1e18;
+      const poolTokenPriceUSD = tokenPrices?.peggedPriceUSD ?? 0;
+      const totalTVL = anchorSupplyNum * poolTokenPriceUSD;
+      const tokenSymbol = market.marketName?.toLowerCase().includes("btc") ? "haBTC" : "haETH";
+
+      const categories = [
+        { name: "Not Deposited", value: anchorNotDeposited, color: "#1E4775" },
+        { name: "Collateral Pool", value: collateralPoolTVL, color: "#B8EBD5" },
+        { name: "Sail Pool", value: sailPoolTVL, color: "#FF8A7A" },
+      ];
+
+      // Calculate percentages for bar (based on Anchor Supply only, no Sail Supply)
+      const notDepositedNum = Number(anchorNotDeposited) / 1e18;
+      const collateralPoolNum = Number(collateralPoolTVL) / 1e18;
+      const sailPoolNum = Number(sailPoolTVL) / 1e18;
+
+      const notDepositedPercent = anchorSupplyNum > 0 ? (notDepositedNum / anchorSupplyNum) * 100 : 0;
+      const collateralPoolPercent = anchorSupplyNum > 0 ? (collateralPoolNum / anchorSupplyNum) * 100 : 0;
+      const sailPoolPercent = anchorSupplyNum > 0 ? (sailPoolNum / anchorSupplyNum) * 100 : 0;
+
+      // TVL Yield Generator: Full TVL (minter's total collateral) converted to wrapped collateral token
+      // Use the minter's total collateral TVL (totalTVLUSD) and wrapped collateral amount
+      const tvlYieldGeneratorUSD = totalTVLUSD; // Full minter TVL in USD
+      // collateralTokensWrapped is already in token units (not wei), convert to wei for formatting
+      const tvlYieldGeneratorWrappedTokenWei = BigInt(Math.floor(collateralTokensWrapped * 1e18));
+      const wrappedCollateralSymbol = market.marketId?.toLowerCase().includes("fxusd") || market.marketId?.toLowerCase().includes("fx-usd") ? "fxSAVE" : "wstETH";
+
+      return (
+        <>
+          {/* First box: TVL USD */}
+          <div className="bg-[#1E4775]/5 p-1.5 text-center">
+            <div className="text-[#1E4775]/60 text-[9px]">TVL USD</div>
+            <div className="text-[#1E4775] font-mono font-semibold text-[10px]">
+              {formatCompactUSD(totalTVL)}
+            </div>
+            <div className="text-[#1E4775]/70 font-mono text-[9px] mt-0.5">
+              {formatTokenBalanceMax2Decimals(anchorSupply)} {tokenSymbol}
+            </div>
+            <div className="text-[#1E4775]/60 font-mono text-[9px]">
+              100.0%
+            </div>
+          </div>
+
+          {/* Second box: TVL Yield Generator */}
+          <div className="bg-[#1E4775]/5 p-1.5 text-center">
+            <div className="text-[#1E4775]/60 text-[9px]">TVL Yield Generator</div>
+            <div className="text-[#1E4775] font-mono font-semibold text-[10px]">
+              {formatCompactUSD(tvlYieldGeneratorUSD)}
+            </div>
+            <div className="text-[#1E4775]/70 font-mono text-[9px] mt-0.5">
+              {formatTokenBalanceMax2Decimals(tvlYieldGeneratorWrappedTokenWei)} {wrappedCollateralSymbol}
+            </div>
+          </div>
+
+          {/* Three category boxes */}
+          {categories.map((category) => {
+            const valueNum = Number(category.value) / 1e18;
+            const usdValue = valueNum * poolTokenPriceUSD;
+            const percent = anchorSupplyNum > 0 ? ((valueNum / anchorSupplyNum) * 100).toFixed(1) : "0.0";
+
+            return (
+              <div key={category.name} className="bg-[#1E4775]/5 p-1.5 text-center">
+                <div className="text-[#1E4775]/60 text-[9px]">{category.name}</div>
+                <div className="text-[#1E4775] font-mono font-semibold text-[10px]">
+                  {formatCompactUSD(usdValue)}
+                </div>
+                <div className="text-[#1E4775]/70 font-mono text-[9px] mt-0.5">
+                  {formatTokenBalanceMax2Decimals(category.value)} {tokenSymbol}
+                </div>
+                <div className="text-[#1E4775]/60 font-mono text-[9px]">
+                  {percent}%
+                </div>
+              </div>
+            );
+          })}
+        </>
+      );
+     })()}
+    </div>
+   </div>
+
+   {/* Bar visualization underneath */}
+   {(() => {
+    const anchorSupply = market.peggedTokenBalance;
+    const collateralPoolTVL = pools.find(p => p.type === "collateral")?.tvl || 0n;
+    const sailPoolTVL = pools.find(p => p.type === "leveraged")?.tvl || 0n;
+    const anchorNotDeposited = anchorSupply > (collateralPoolTVL + sailPoolTVL) 
+      ? anchorSupply - collateralPoolTVL - sailPoolTVL 
+      : 0n;
+    
+    const anchorSupplyNum = Number(anchorSupply) / 1e18;
+    const notDepositedNum = Number(anchorNotDeposited) / 1e18;
+    const collateralPoolNum = Number(collateralPoolTVL) / 1e18;
+    const sailPoolNum = Number(sailPoolTVL) / 1e18;
+
+    const notDepositedPercent = anchorSupplyNum > 0 ? (notDepositedNum / anchorSupplyNum) * 100 : 0;
+    const collateralPoolPercent = anchorSupplyNum > 0 ? (collateralPoolNum / anchorSupplyNum) * 100 : 0;
+    const sailPoolPercent = anchorSupplyNum > 0 ? (sailPoolNum / anchorSupplyNum) * 100 : 0;
+
+    return (
+      <div className="flex items-center gap-2">
+       <div className="w-12"></div>
+       <div className="flex-1 space-y-1">
+        {/* Yield/No Yield indicator above bar */}
+        <div className="relative flex items-center text-[8px] text-[#1E4775]/60 px-1" style={{ height: '14px' }}>
+          {/* No yield label on left with arrow, aligned to pipe */}
+          <span 
+            className="absolute whitespace-nowrap text-right"
+            style={{ 
+              right: `${100 - notDepositedPercent}%`,
+              paddingRight: '12px'
+            }}
+          >
+            ⟵ no yield
+          </span>
+          {/* Yield label on right with arrow, aligned to pipe */}
+          <span 
+            className="absolute whitespace-nowrap text-left"
+            style={{ 
+              left: `${notDepositedPercent}%`,
+              paddingLeft: '12px'
+            }}
+          >
+            yield ⟶
+          </span>
+        </div>
+
+        {/* Bar container */}
+        <div className="relative h-4 bg-[#1E4775]/10 rounded overflow-visible">
+          {/* Bar segments */}
+          {notDepositedPercent > 0 && (
+            <div 
+              className="absolute top-0 bottom-0 bg-[#1E4775] rounded-l"
+              style={{ left: '0%', width: `${notDepositedPercent}%` }}
+            />
+          )}
+          {collateralPoolPercent > 0 && (
+            <div 
+              className="absolute top-0 bottom-0 bg-[#B8EBD5]"
+              style={{ left: `${notDepositedPercent}%`, width: `${collateralPoolPercent}%` }}
+            />
+          )}
+          {sailPoolPercent > 0 && (
+            <div 
+              className="absolute top-0 bottom-0 bg-[#FF8A7A] rounded-r"
+              style={{ left: `${notDepositedPercent + collateralPoolPercent}%`, width: `${sailPoolPercent}%` }}
+            />
+          )}
+
+          {/* Vertical pipe/divider between yield and no yield - extends 10px above and below bar */}
+          {/* No yield = Not Deposited; Yield = Collateral Pool + Sail Pool */}
+          <div 
+            className="absolute w-0.5 bg-red-500 z-10"
+            style={{ 
+              left: `${notDepositedPercent}%`,
+              top: '-10px',
+              bottom: '-10px'
+            }}
+          />
+        </div>
+
+        {/* Pool names below bar - aligned with segments */}
+        <div className="relative flex text-[8px] text-[#1E4775]/60 px-1" style={{ height: '16px' }}>
+          <div 
+            className="absolute text-center"
+            style={{ left: '0%', width: `${notDepositedPercent}%` }}
+          >
+            Not Deposited
+          </div>
+          <div 
+            className="absolute text-center"
+            style={{ left: `${notDepositedPercent}%`, width: `${collateralPoolPercent}%` }}
+          >
+            Collateral Pool
+          </div>
+          <div 
+            className="absolute text-center"
+            style={{ left: `${notDepositedPercent + collateralPoolPercent}%`, width: `${sailPoolPercent}%` }}
+          >
+            Sail Pool
+          </div>
+        </div>
+       </div>
+      </div>
+    );
+   })()}
+  </div>
+ </div>
  </div>
  </div>
  </div>

--- a/src/app/transparency/page.tsx
+++ b/src/app/transparency/page.tsx
@@ -698,7 +698,7 @@ function MarketCard({
 
  <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
  {/* Token Prices & Supply */}
- <div className="bg-white p-2.5 space-y-2">
+ <div className="bg-white p-2.5 space-y-2 lg:row-span-2">
  <h4 className="text-[#1E4775] font-semibold text-xs uppercase tracking-wider mb-2">
  Prices & Supply
  </h4>
@@ -818,11 +818,11 @@ function MarketCard({
 
     {/* Distribution Pie Chart */}
     {distributionData.length > 0 && (
-      <div className="mt-2">
+      <div className="mt-2 mb-1">
         <h5 className="text-[#1E4775] font-semibold text-[10px] uppercase tracking-wider mb-1.5">
           Supply Distribution
         </h5>
-        <div className="w-full" style={{ height: "180px" }}>
+        <div className="w-full" style={{ height: "220px" }}>
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
@@ -831,7 +831,7 @@ function MarketCard({
                 cy="50%"
                 labelLine={false}
                 label={false}
-                outerRadius={65}
+                outerRadius={80}
                 fill="#8884d8"
                 dataKey="value"
               >
@@ -840,11 +840,11 @@ function MarketCard({
                   if (entry.name === "Not Deposited") {
                     color = "#1E4775"; // harbor-blue
                   } else if (entry.name === "Collateral Pool") {
-                    color = "#B8EBD5"; // harbor-mint (seafoam green)
+                    color = "#9ED5BE"; // toned down seafoam green
                   } else if (entry.name === "Sail Pool") {
                     color = "#FF8A7A"; // harbor-coral (pearl orange)
                   } else if (entry.name === "Sail Supply") {
-                    color = "#FCD34D"; // yellow sun
+                    color = "#E9C46A"; // yellow
                   }
                   return <Cell key={`cell-${index}`} fill={color} stroke="#1E4775" strokeWidth={entry.name === "Sail Pool" ? 0 : 0} />;
                 })}
@@ -863,16 +863,17 @@ function MarketCard({
                 wrapperStyle={{ 
                   fontSize: '9px', 
                   paddingTop: '8px',
-                  paddingBottom: '8px',
+                  paddingBottom: '4px',
                   paddingLeft: '8px',
                   paddingRight: '8px',
                   backgroundColor: 'rgba(30, 71, 117, 0.05)', // #1E4775/5
                   borderRadius: '4px',
                   marginTop: '8px',
+                  marginBottom: '0px',
                   display: 'flex',
                   justifyContent: 'center',
                   flexWrap: 'nowrap',
-                  gap: '16px',
+                  gap: '32px',
                   overflow: 'hidden'
                 }}
                 layout="horizontal"
@@ -974,13 +975,19 @@ function MarketCard({
  </div>
  );
  })}
+ </div>
+ </div>
 
- {/* Anchor Supply TVL Row with Bar Visualization */}
- <div className="space-y-2 mt-2 pt-2 border-t border-[#1E4775]/10">
+ {/* Yield (Anchor Supply) */}
+ <div className="bg-white p-2.5 space-y-2 lg:col-span-2">
+ <h4 className="text-[#1E4775] font-semibold text-xs uppercase tracking-wider mb-2">
+ Anchor Supply
+ </h4>
+ <div className="space-y-2">
   <div className="flex flex-col gap-2">
    <div className="flex items-center gap-2">
     <span className="text-[#1E4775] font-semibold text-[10px] w-12">
-     Anchor supply
+     Yield
     </span>
     <div className="grid grid-cols-5 gap-1.5 text-xs flex-1">
      {(() => {
@@ -998,7 +1005,7 @@ function MarketCard({
 
       const categories = [
         { name: "Not Deposited", value: anchorNotDeposited, color: "#1E4775" },
-        { name: "Collateral Pool", value: collateralPoolTVL, color: "#B8EBD5" },
+        { name: "Collateral Pool", value: collateralPoolTVL, color: "#9ED5BE" },
         { name: "Sail Pool", value: sailPoolTVL, color: "#FF8A7A" },
       ];
 
@@ -1129,8 +1136,8 @@ function MarketCard({
           )}
           {collateralPoolPercent > 0 && (
             <div 
-              className="absolute top-0 bottom-0 bg-[#B8EBD5]"
-              style={{ left: `${notDepositedPercent}%`, width: `${collateralPoolPercent}%` }}
+              className="absolute top-0 bottom-0"
+              style={{ backgroundColor: "#9ED5BE", left: `${notDepositedPercent}%`, width: `${collateralPoolPercent}%` }}
             />
           )}
           {sailPoolPercent > 0 && (
@@ -1178,7 +1185,6 @@ function MarketCard({
     );
    })()}
   </div>
- </div>
  </div>
  </div>
  </div>

--- a/src/components/AnchorClaimAllModal.tsx
+++ b/src/components/AnchorClaimAllModal.tsx
@@ -95,7 +95,7 @@ export const AnchorClaimAllModal = ({
  onClick={onClose}
  />
 
-        <div className="relative bg-white shadow-2xl w-full max-w-4xl mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 flex flex-col max-h-[95vh] sm:max-h-[90vh] rounded-lg">
+        <div className="relative bg-white shadow-2xl w-full max-w-4xl mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 flex flex-col max-h-[95vh] sm:max-h-[90vh] rounded-none">
           <div className="flex items-center justify-between p-3 sm:p-4 lg:p-6 border-b border-[#1E4775]/20">
  <h2 className="text-2xl font-bold text-[#1E4775]">Claim Rewards</h2>
  <button

--- a/src/components/AnchorClaimMarketModal.tsx
+++ b/src/components/AnchorClaimMarketModal.tsx
@@ -31,7 +31,7 @@ export const AnchorClaimMarketModal = ({
  onClick={onClose}
  />
 
-        <div className="relative bg-white shadow-2xl w-full max-w-md mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 rounded-lg max-h-[95vh] sm:max-h-[90vh] overflow-y-auto">
+        <div className="relative bg-white shadow-2xl w-full max-w-md mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 rounded-none max-h-[95vh] sm:max-h-[90vh] overflow-y-auto">
           <div className="flex items-center justify-between p-3 sm:p-4 lg:p-6 border-b border-[#1E4775]/20">
  <h2 className="text-2xl font-bold text-[#1E4775]">Claim {marketSymbol} Rewards</h2>
  <button

--- a/src/components/AnchorCompoundModal.tsx
+++ b/src/components/AnchorCompoundModal.tsx
@@ -41,7 +41,7 @@ export const AnchorCompoundModal = ({
  onClick={onClose}
  />
 
-        <div className="relative bg-white shadow-2xl w-full max-w-md mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 rounded-lg max-h-[95vh] sm:max-h-[90vh] overflow-y-auto">
+        <div className="relative bg-white shadow-2xl w-full max-w-md mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 rounded-none max-h-[95vh] sm:max-h-[90vh] overflow-y-auto">
           <div className="flex items-center justify-between p-3 sm:p-4 lg:p-6 border-b border-[#1E4775]/20">
  <h2 className="text-2xl font-bold text-[#1E4775]">Compound Rewards</h2>
  <button

--- a/src/components/AnchorDepositModal.tsx
+++ b/src/components/AnchorDepositModal.tsx
@@ -472,7 +472,7 @@ export const AnchorDepositModal = ({
  onClick={handleClose}
  />
 
-        <div className="relative bg-white shadow-2xl w-full max-w-md mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 rounded-lg max-h-[95vh] sm:max-h-[90vh] overflow-y-auto">
+        <div className="relative bg-white shadow-2xl w-full max-w-md mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 rounded-none max-h-[95vh] sm:max-h-[90vh] overflow-y-auto">
  <div className="flex items-center justify-between p-6 border-b border-[#1E4775]/20">
  <h2 className="text-2xl font-bold text-[#1E4775]">Deposit</h2>
  <button

--- a/src/components/CompoundConfirmationModal.tsx
+++ b/src/components/CompoundConfirmationModal.tsx
@@ -106,7 +106,7 @@ export const CompoundConfirmationModal = ({
  className="absolute inset-0 bg-black/40 backdrop-blur-sm"
  onClick={onClose}
  />
-        <div className="relative bg-white shadow-2xl w-full max-w-md mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 max-h-[95vh] sm:max-h-[90vh] overflow-y-auto rounded-lg">
+        <div className="relative bg-white shadow-2xl w-full max-w-md mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 max-h-[95vh] sm:max-h-[90vh] overflow-y-auto rounded-none">
  <div className="flex items-center justify-between p-3 border-b border-[#1E4775]/20">
  <h2 className="text-base font-bold text-[#1E4775]">Compound Rewards</h2>
  <button

--- a/src/components/CompoundPoolSelectionModal.tsx
+++ b/src/components/CompoundPoolSelectionModal.tsx
@@ -23,7 +23,7 @@ function formatCompactUSD(value: number): string {
 }
 
 export interface PoolOption {
- id:"collateral" |"sail";
+ id: string;
  name: string;
  address: `0x${string}`;
  apr?: number;
@@ -33,7 +33,7 @@ export interface PoolOption {
 }
 
 interface PoolAllocation {
- poolId:"collateral" |"sail";
+ poolAddress: `0x${string}`;
  percentage: number;
 }
 
@@ -53,68 +53,72 @@ export const CompoundPoolSelectionModal = ({
  marketSymbol,
 }: CompoundPoolSelectionModalProps) => {
  const availablePools = pools.filter((p) => p.enabled);
- 
- // Initialize with 50/50 split if 2 pools, 100% if 1 pool
- const [allocations, setAllocations] = useState<Map<"collateral" |"sail", number>>(() => {
- const map = new Map();
- if (availablePools.length === 1) {
- map.set(availablePools[0].id, 100);
- } else if (availablePools.length === 2) {
- map.set(availablePools[0].id, 50);
- map.set(availablePools[1].id, 50);
- }
- return map;
- });
+ const [selected, setSelected] = useState<Set<string>>(new Set());
+ const [percentages, setPercentages] = useState<Map<string, number>>(new Map());
 
  useEffect(() => {
- // Reset allocations when modal opens
- if (isOpen) {
- const map = new Map();
- if (availablePools.length === 1) {
- map.set(availablePools[0].id, 100);
- } else if (availablePools.length === 2) {
- map.set(availablePools[0].id, 50);
- map.set(availablePools[1].id, 50);
- }
- setAllocations(map);
- }
- }, [isOpen, availablePools.length]);
+   if (!isOpen) return;
+   // Default: select none; user opts in explicitly.
+   setSelected(new Set());
+   setPercentages(new Map());
+ }, [isOpen]);
 
  if (!isOpen) return null;
 
- console.log("[CompoundPoolSelectionModal] Rendering with:", {
- isOpen,
- poolsCount: pools.length,
- availablePoolsCount: availablePools.length,
- marketSymbol,
- allocations: Object.fromEntries(allocations),
- });
-
- const handleSliderChange = (value: number) => {
- if (availablePools.length !== 2) return;
- 
- // Reverse the slider value: slider at 0 (left) = 100% collateral, slider at 100 (right) = 0% collateral
- const newAllocations = new Map(allocations);
- newAllocations.set("collateral", 100 - value);
- newAllocations.set("sail", value);
- setAllocations(newAllocations);
- };
+ const totalPct = Array.from(selected).reduce(
+   (sum, addr) => sum + (percentages.get(addr) || 0),
+   0
+ );
+ const pctError =
+   selected.size > 0 && totalPct !== 100 ? "Percentages must add up to 100%" : null;
 
  const handleConfirm = () => {
- console.log("[CompoundPoolSelectionModal] handleConfirm called");
- console.log("[CompoundPoolSelectionModal] allocations:", Object.fromEntries(allocations));
- const allocationArray: PoolAllocation[] = Array.from(allocations.entries()).map(([poolId, percentage]) => ({
- poolId,
- percentage,
- }));
- console.log("[CompoundPoolSelectionModal] allocationArray:", allocationArray);
- onConfirm(allocationArray);
+   if (selected.size === 0) return;
+   if (pctError) return;
+   const allocationArray: PoolAllocation[] = Array.from(selected).map((addr) => ({
+     poolAddress: addr as `0x${string}`,
+     percentage: percentages.get(addr) || 0,
+   }));
+   onConfirm(allocationArray);
  };
 
- const collateralPool = availablePools.find(p => p.id ==="collateral");
- const sailPool = availablePools.find(p => p.id ==="sail");
- const collateralPercentage = allocations.get("collateral") || 0;
- const sailPercentage = allocations.get("sail") || 0;
+ const togglePool = (addr: string) => {
+   setSelected((prev) => {
+     const next = new Set(prev);
+     if (next.has(addr)) next.delete(addr);
+     else next.add(addr);
+     return next;
+   });
+   setPercentages((prev) => {
+     const next = new Map(prev);
+     if (selected.has(addr)) {
+       // Removing
+       next.delete(addr);
+     } else {
+       // Adding
+       next.set(addr, 0);
+     }
+     return next;
+   });
+   // If this becomes the only selected pool, auto-set it to 100% for convenience.
+   setTimeout(() => {
+     setSelected((prevSel) => {
+       if (prevSel.size !== 1) return prevSel;
+       const only = Array.from(prevSel)[0];
+       setPercentages((prevPct) => {
+         const nextPct = new Map(prevPct);
+         nextPct.set(only, 100);
+         return nextPct;
+       });
+       return prevSel;
+     });
+   }, 0);
+ };
+
+ const setPoolPct = (addr: string, value: number) => {
+   const clamped = Math.max(0, Math.min(100, value));
+   setPercentages((prev) => new Map(prev).set(addr, clamped));
+ };
 
  return (
  <div className="fixed inset-0 z-[70] flex items-center justify-center">
@@ -122,7 +126,7 @@ export const CompoundPoolSelectionModal = ({
  className="absolute inset-0 bg-black/40 backdrop-blur-sm"
  onClick={onClose}
  />
-        <div className="relative bg-white shadow-2xl w-full max-w-md mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 rounded-lg max-h-[95vh] sm:max-h-[90vh] overflow-y-auto">
+        <div className="relative bg-white shadow-2xl w-full max-w-md mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 rounded-none max-h-[95vh] sm:max-h-[90vh] overflow-y-auto">
  <div className="flex items-center justify-between p-4 border-b border-[#1E4775]/20">
  <h2 className="text-xl font-bold text-[#1E4775]">Select Pools to Compound To</h2>
  <button
@@ -156,93 +160,58 @@ export const CompoundPoolSelectionModal = ({
  </div>
  )}
 
- {availablePools.length === 1 && collateralPool && (
- <div className="p-4 border-2 border-[#1E4775] bg-[#1E4775]/5">
- <div className="flex items-center justify-between mb-2">
- <div>
- <div className="font-semibold text-[#1E4775]">
- {collateralPool.name}
- </div>
- {collateralPool.apr !== undefined && (
- <div className="text-sm text-[#1E4775]/70 mt-0.5">
- APR: {collateralPool.apr.toFixed(2)}%
- </div>
- )}
- {collateralPool.tvlUSD !== undefined && (
- <div className="text-sm text-[#1E4775]/70 mt-0.5">
- TVL: {formatCompactUSD(collateralPool.tvlUSD)}
- </div>
- )}
- </div>
- <div className="text-2xl font-bold text-[#1E4775]">
- 100%
- </div>
- </div>
- </div>
- )}
+ {availablePools.length > 0 && (
+   <div className="space-y-2">
+     {availablePools.map((p) => {
+       const addr = p.address.toLowerCase();
+       const isSelected = selected.has(addr);
+       const showPct = selected.size > 1 && isSelected;
+       const pct = percentages.get(addr) ?? 0;
+       return (
+         <div key={p.address} className="border border-[#1E4775]/20 p-3">
+           <div className="flex items-start justify-between gap-3">
+             <label className="flex items-start gap-3 cursor-pointer">
+               <input
+                 type="checkbox"
+                 checked={isSelected}
+                 onChange={() => togglePool(addr)}
+                 className="mt-1"
+               />
+               <div className="min-w-0">
+                 <div className="font-semibold text-[#1E4775] truncate">
+                   {p.name}
+                 </div>
+                 <div className="text-xs text-[#1E4775]/70 mt-1">
+                   APR: {p.apr !== undefined ? `${p.apr.toFixed(2)}%` : "—"}
+                   {"  "}•{"  "}
+                   TVL: {p.tvlUSD !== undefined ? formatCompactUSD(p.tvlUSD) : "—"}
+                 </div>
+               </div>
+             </label>
 
- {availablePools.length === 2 && collateralPool && sailPool && (
- <div className="space-y-4">
- {/* Single Slider with Pools on Each Side */}
- <div className="p-4 border-2 border-[#1E4775] bg-[#1E4775]/5">
- <div className="flex items-start justify-between mb-4 gap-4">
- {/* Left Pool (Collateral) */}
- <div className="flex-1 text-left">
- <div className="font-semibold text-[#1E4775] text-sm mb-1">
- {collateralPool.name}
- </div>
- {collateralPool.apr !== undefined && (
- <div className="text-xs text-[#1E4775]/70">
- APR: {collateralPool.apr.toFixed(2)}%
- </div>
- )}
- {collateralPool.tvlUSD !== undefined && (
- <div className="text-xs text-[#1E4775]/70">
- TVL: {formatCompactUSD(collateralPool.tvlUSD)}
- </div>
- )}
- <div className="text-2xl font-bold text-[#1E4775] mt-2">
- {collateralPercentage}%
- </div>
- </div>
-
- {/* Right Pool (Sail) */}
- <div className="flex-1 text-right">
- <div className="font-semibold text-[#1E4775] text-sm mb-1">
- {sailPool.name}
- </div>
- {sailPool.apr !== undefined && (
- <div className="text-xs text-[#1E4775]/70">
- APR: {sailPool.apr.toFixed(2)}%
- </div>
- )}
- {sailPool.tvlUSD !== undefined && (
- <div className="text-xs text-[#1E4775]/70">
- TVL: {formatCompactUSD(sailPool.tvlUSD)}
- </div>
- )}
- <div className="text-2xl font-bold text-[#1E4775] mt-2">
- {sailPercentage}%
- </div>
- </div>
- </div>
-
- {/* Single Slider */}
- <div className="relative mt-4">
- <input
- type="range"
- min="0"
- max="100"
- value={sailPercentage}
- onChange={(e) => handleSliderChange(parseInt(e.target.value))}
- className="w-full h-3 bg-[#1E4775]/20 appearance-none cursor-pointer accent-[#1E4775]"
- style={{
- background: `linear-gradient(to right, #1E4775 0%, #1E4775 ${sailPercentage}%, rgba(30, 71, 117, 0.2) ${sailPercentage}%, rgba(30, 71, 117, 0.2) 100%)`
- }}
- />
- </div>
- </div>
- </div>
+             {showPct && (
+               <div className="flex items-center gap-2">
+                 <input
+                   type="number"
+                   min={0}
+                   max={100}
+                   value={pct}
+                   onChange={(e) => setPoolPct(addr, Number(e.target.value))}
+                   className="w-20 px-2 py-1 border border-[#1E4775]/30 text-[#1E4775] text-sm"
+                 />
+                 <span className="text-sm text-[#1E4775]/70">%</span>
+               </div>
+             )}
+           </div>
+         </div>
+       );
+     })}
+     {selected.size > 1 && (
+       <div className="text-xs text-[#1E4775]/70">
+         Total: {totalPct}% {pctError ? <span className="text-rose-600">({pctError})</span> : null}
+       </div>
+     )}
+   </div>
  )}
 
  <div className="flex gap-2 pt-2">
@@ -254,7 +223,7 @@ export const CompoundPoolSelectionModal = ({
  </button>
  <button
  onClick={handleConfirm}
- disabled={availablePools.length === 0}
+  disabled={availablePools.length === 0 || selected.size === 0 || !!pctError}
  className="flex-1 px-4 py-2 text-sm font-medium bg-[#1E4775] text-white hover:bg-[#17395F] disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed transition-colors rounded-full"
  >
  Continue

--- a/src/components/CompoundTargetTokenModal.tsx
+++ b/src/components/CompoundTargetTokenModal.tsx
@@ -1,0 +1,649 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+
+export type CompoundTargetMode = "single-token" | "keep-per-token";
+
+export interface CompoundSelectedPosition {
+  marketId: string;
+  market: any;
+  poolType: "collateral" | "sail";
+  rewardsUSD: number;
+  rewardTokens: Array<{
+    symbol: string;
+    claimable: bigint;
+    claimableFormatted: string;
+  }>;
+}
+
+export interface CompoundTargetPoolApr {
+  marketId: string;
+  collateralSymbol: string; // e.g. fxSAVE / wstETH
+  poolType: "collateral" | "sail";
+  poolAddress: `0x${string}`;
+  apr?: number; // %
+}
+
+export interface CompoundTargetOption {
+  // Representative market used as an "anchor" for next step; APRs can span multiple markets.
+  marketId: string;
+  symbol: string; // e.g. haBTC
+  pools: CompoundTargetPoolApr[];
+}
+
+interface CompoundTargetTokenModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  positions: CompoundSelectedPosition[];
+  options: CompoundTargetOption[];
+  selectedClaimPools: Array<{ marketId: string; poolType: "collateral" | "sail" }>;
+  preflight:
+    | {
+        key: string;
+        isLoading: boolean;
+        error?: string;
+        fees: Array<{
+          id: string;
+          label: string;
+          tokenSymbol: string;
+          feeFormatted: string;
+          feePercentage?: number;
+          details?: string;
+        }>;
+      }
+    | null;
+  simplePreflight:
+    | {
+        key: string;
+        isLoading: boolean;
+        error?: string;
+        fees: Array<{
+          id: string;
+          label: string;
+          tokenSymbol: string;
+          feeFormatted: string;
+          feePercentage?: number;
+          details?: string;
+        }>;
+      }
+    | null;
+  onPreflight: (args: {
+    targetMarketId: string;
+    allocations: Array<{ poolAddress: `0x${string}`; percentage: number }>;
+    selectedClaimPools: Array<{ marketId: string; poolType: "collateral" | "sail" }>;
+  }) => void;
+  onSimplePreflight: (args: {
+    selectedClaimPools: Array<{ marketId: string; poolType: "collateral" | "sail" }>;
+  }) => void;
+  onContinue: (args: {
+    mode: CompoundTargetMode;
+    targetMarketId?: string;
+    allocations?: Array<{ poolAddress: `0x${string}`; percentage: number }>;
+  }) => void;
+}
+
+export const CompoundTargetTokenModal = ({
+  isOpen,
+  onClose,
+  positions,
+  options,
+  selectedClaimPools,
+  preflight,
+  simplePreflight,
+  onPreflight,
+  onSimplePreflight,
+  onContinue,
+}: CompoundTargetTokenModalProps) => {
+  const [mode, setMode] = useState<CompoundTargetMode>("keep-per-token");
+  const [targetMarketId, setTargetMarketId] = useState<string | undefined>(
+    options[0]?.marketId
+  );
+  const [selectedPools, setSelectedPools] = useState<Set<string>>(new Set());
+  const [percentages, setPercentages] = useState<Map<string, number>>(new Map());
+
+  // Keep default selection in sync when options change (e.g. when user re-opens modal)
+  useEffect(() => {
+    if (!isOpen) return;
+    if (!targetMarketId || !options.some((o) => o.marketId === targetMarketId)) {
+      setTargetMarketId(options[0]?.marketId);
+    }
+    // Default to Simple compound each time the modal opens.
+    setMode("keep-per-token");
+    setSelectedPools(new Set());
+    setPercentages(new Map());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, options]);
+
+  const collateralGroups = useMemo(() => {
+    const set = new Set(options.flatMap((o) => o.pools.map((p) => p.collateralSymbol)));
+    return Array.from(set);
+  }, [options]);
+
+  const canSingleToken = options.length > 0;
+  const selectedTokenOption = useMemo(
+    () => options.find((o) => o.marketId === targetMarketId),
+    [options, targetMarketId]
+  );
+
+  const tokenFilterItems = useMemo(() => {
+    return options.map((o) => {
+      const aprs = o.pools
+        .map((p) => p.apr)
+        .filter((x): x is number => x !== undefined);
+      const min = aprs.length ? Math.min(...aprs) : undefined;
+      const max = aprs.length ? Math.max(...aprs) : undefined;
+      return {
+        marketId: o.marketId,
+        symbol: o.symbol,
+        min,
+        max,
+        poolsCount: o.pools.length,
+      };
+    });
+  }, [options]);
+
+  const totalPct = useMemo(() => {
+    return Array.from(selectedPools).reduce(
+      (sum, addr) => sum + (percentages.get(addr) || 0),
+      0
+    );
+  }, [selectedPools, percentages]);
+
+  const pctError =
+    mode === "single-token" && selectedPools.size > 0 && totalPct !== 100
+      ? "Percentages must add up to 100%"
+      : null;
+
+  const allocationArray = useMemo(() => {
+    return Array.from(selectedPools).map((addrLower) => ({
+      poolAddress: addrLower as `0x${string}`,
+      percentage: percentages.get(addrLower) || 0,
+    }));
+  }, [selectedPools, percentages]);
+
+  const preflightKey = useMemo(() => {
+    if (!targetMarketId) return "";
+    const a = allocationArray
+      .slice()
+      .sort((x, y) => x.poolAddress.localeCompare(y.poolAddress))
+      .map((x) => [x.poolAddress.toLowerCase(), x.percentage]);
+    const c = selectedClaimPools
+      .slice()
+      .sort((x, y) => `${x.marketId}-${x.poolType}`.localeCompare(`${y.marketId}-${y.poolType}`));
+    return JSON.stringify({ t: targetMarketId, a, c });
+  }, [allocationArray, selectedClaimPools, targetMarketId]);
+
+  const simplePreflightKey = useMemo(() => {
+    const c = selectedClaimPools
+      .slice()
+      .sort((x, y) =>
+        `${x.marketId}-${x.poolType}`.localeCompare(`${y.marketId}-${y.poolType}`)
+      );
+    return JSON.stringify({ c });
+  }, [selectedClaimPools]);
+
+  // Auto-run fee previews (no user button).
+  useEffect(() => {
+    if (!isOpen) return;
+
+    if (mode === "keep-per-token") {
+      const isFresh = !!simplePreflight && simplePreflight.key === simplePreflightKey;
+      if (!isFresh && !(simplePreflight?.isLoading && simplePreflight.key === simplePreflightKey)) {
+        onSimplePreflight({ selectedClaimPools });
+      }
+      return;
+    }
+
+    if (mode === "single-token") {
+      if (!targetMarketId) return;
+      if (selectedPools.size === 0) return;
+      if (pctError) return;
+
+      const isFresh = preflight && preflight.key === preflightKey;
+      if (!isFresh && !(preflight?.isLoading && preflight.key === preflightKey)) {
+        onPreflight({
+          targetMarketId,
+          allocations: allocationArray,
+          selectedClaimPools,
+        });
+      }
+    }
+  }, [
+    allocationArray,
+    isOpen,
+    mode,
+    onPreflight,
+    onSimplePreflight,
+    pctError,
+    preflight,
+    preflightKey,
+    selectedClaimPools,
+    selectedPools.size,
+    simplePreflight,
+    simplePreflightKey,
+    targetMarketId,
+  ]);
+
+  const togglePool = (addrLower: string) => {
+    setSelectedPools((prev) => {
+      const next = new Set(prev);
+      if (next.has(addrLower)) next.delete(addrLower);
+      else next.add(addrLower);
+      return next;
+    });
+    setPercentages((prev) => {
+      const next = new Map(prev);
+      if (next.has(addrLower)) next.delete(addrLower);
+      else next.set(addrLower, 0);
+      return next;
+    });
+    // If this becomes the only selected pool, auto-set it to 100%
+    setTimeout(() => {
+      setSelectedPools((prevSel) => {
+        if (prevSel.size !== 1) return prevSel;
+        const only = Array.from(prevSel)[0];
+        setPercentages((prevPct) => {
+          const nextPct = new Map(prevPct);
+          nextPct.set(only, 100);
+          return nextPct;
+        });
+        return prevSel;
+      });
+    }, 0);
+  };
+
+  const setPoolPct = (addrLower: string, value: number) => {
+    const clamped = Math.max(0, Math.min(100, value));
+    setPercentages((prev) => new Map(prev).set(addrLower, clamped));
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[65] flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      <div className="relative bg-white shadow-2xl w-full max-w-3xl mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 flex flex-col max-h-[95vh] sm:max-h-[90vh] rounded-none overflow-hidden">
+        <div className="flex items-center justify-between p-3 sm:p-4 lg:p-6 border-b border-[#1E4775]/20">
+          <h2 className="text-2xl font-bold text-[#1E4775]">
+            Choose Anchor Token to Compound To
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-[#1E4775]/50 hover:text-[#1E4775] transition-colors"
+          >
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="p-4 sm:p-6 flex-1 overflow-y-auto space-y-6">
+          <div>
+            <div className="text-sm font-semibold text-[#1E4775] mb-2">
+              Selected positions
+            </div>
+            <div className="border border-[#1E4775]/20">
+              {positions.map((p) => {
+                const symbol = p.market?.peggedToken?.symbol || p.marketId;
+                return (
+                  <div
+                    key={`${p.marketId}-${p.poolType}`}
+                    className="flex items-center justify-between px-3 py-2 border-b border-[#1E4775]/10 last:border-b-0"
+                  >
+                    <div className="min-w-0">
+                      <div className="text-sm font-semibold text-[#1E4775] truncate">
+                        {symbol} {p.poolType} pool
+                      </div>
+                      <div className="text-xs text-[#1E4775]/70">
+                        {p.rewardTokens
+                          ?.map((t) => `${t.claimableFormatted} ${t.symbol}`)
+                          .join(", ")}
+                      </div>
+                    </div>
+                    <div className="text-sm font-semibold text-[#1E4775]">
+                      ${p.rewardsUSD.toFixed(2)}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <div className="text-sm font-semibold text-[#1E4775]">
+              Compounding mode
+            </div>
+
+            <label className="flex items-start gap-3 p-3 border border-[#1E4775]/20">
+              <input
+                type="radio"
+                checked={mode === "keep-per-token"}
+                onChange={() => setMode("keep-per-token")}
+                className="mt-1"
+              />
+              <div className="flex-1">
+                <div className="font-semibold text-[#1E4775]">
+                  Simple compound
+                </div>
+                <div className="text-xs text-[#1E4775]/70 mt-1">
+                  Claim rewards, convert to Anchor tokens, deposit back into original stability pools.
+                </div>
+
+                {/* Fee preview (auto) */}
+                <div className="pt-3 mt-3 border-t border-[#1E4775]/15 space-y-2">
+                  <div className="text-xs font-semibold text-[#1E4775]/80 uppercase tracking-wide">
+                    Estimated fees (dry run)
+                  </div>
+
+                  {simplePreflight?.key !== simplePreflightKey && (
+                    <div className="text-xs text-[#1E4775]/70">
+                      Calculating…
+                    </div>
+                  )}
+
+                  {simplePreflight?.isLoading && (
+                    <div className="text-xs text-[#1E4775]/70">
+                      Calculating…
+                    </div>
+                  )}
+
+                  {simplePreflight?.error && simplePreflight.key === simplePreflightKey && (
+                    <div className="text-xs text-rose-600">{simplePreflight.error}</div>
+                  )}
+
+                  {simplePreflight &&
+                  !simplePreflight.isLoading &&
+                  !simplePreflight.error &&
+                  simplePreflight.key === simplePreflightKey ? (
+                    simplePreflight.fees.length ? (
+                      <div className="space-y-2">
+                        {simplePreflight.fees.map((f) => (
+                          <div
+                            key={f.id}
+                            className="p-2 border border-amber-200 bg-amber-50 text-xs"
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <div className="font-semibold text-amber-900">
+                                {f.label}
+                              </div>
+                              <div className="font-mono font-semibold text-amber-900">
+                                {f.feeFormatted} {f.tokenSymbol}
+                                {f.feePercentage !== undefined && (
+                                  <span className="text-amber-700 ml-2">
+                                    ({f.feePercentage.toFixed(2)}%)
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                            {f.details && (
+                              <div className="text-amber-800/80 mt-1">{f.details}</div>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="text-xs text-[#1E4775]/70">
+                        No protocol fees detected for your current rewards.
+                      </div>
+                    )
+                  ) : null}
+                </div>
+              </div>
+            </label>
+
+            <label
+              className={`flex items-start gap-3 p-3 border border-[#1E4775]/20 ${
+                !canSingleToken ? "opacity-50" : ""
+              }`}
+            >
+              <input
+                type="radio"
+                checked={mode === "single-token"}
+                onChange={() => setMode("single-token")}
+                disabled={!canSingleToken}
+                className="mt-1"
+              />
+              <div className="flex-1">
+                <div className="font-semibold text-[#1E4775]">
+                  Advanced compound
+                </div>
+                <div className="text-xs text-[#1E4775]/70 mt-1">
+                  Claim rewards and allocate to any stability pools
+                </div>
+
+                {mode === "single-token" && canSingleToken && (
+                  <div className="mt-3 space-y-3">
+                    {/* Filter by Anchor token (shows APR range across all pools) */}
+                    <div className="space-y-2">
+                      <div className="text-xs font-semibold text-[#1E4775]/80 uppercase tracking-wide">
+                        Filter by Anchor token
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        {tokenFilterItems.map((t) => (
+                          <button
+                            key={t.marketId}
+                            type="button"
+                            onClick={() => {
+                              setTargetMarketId(t.marketId);
+                              setSelectedPools(new Set());
+                              setPercentages(new Map());
+                            }}
+                            className={`px-3 py-1.5 border text-sm transition-colors ${
+                              targetMarketId === t.marketId
+                                ? "border-[#1E4775] bg-[#1E4775]/5 text-[#1E4775]"
+                                : "border-[#1E4775]/20 hover:bg-[#1E4775]/5 text-[#1E4775]"
+                            }`}
+                          >
+                            <span className="font-semibold">{t.symbol}</span>
+                            <span className="text-[#1E4775]/70 ml-2">
+                              {t.min !== undefined && t.max !== undefined
+                                ? t.min === t.max
+                                  ? `${t.min.toFixed(2)}%`
+                                  : `${t.min.toFixed(2)}–${t.max.toFixed(2)}%`
+                                : "—"}
+                            </span>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    {/* Pool allocation list (by address) */}
+                    {selectedTokenOption && (
+                      <div className="space-y-2">
+                        <div className="text-xs font-semibold text-[#1E4775]/80 uppercase tracking-wide">
+                          Choose stability pools
+                        </div>
+                        <div className="space-y-2">
+                          {[...selectedTokenOption.pools]
+                            .sort((a, b) => (b.apr ?? -Infinity) - (a.apr ?? -Infinity))
+                            .map((p) => {
+                              const addrLower = p.poolAddress.toLowerCase();
+                              const isSelected = selectedPools.has(addrLower);
+                              const showPct = selectedPools.size > 1 && isSelected;
+                              const pct = percentages.get(addrLower) ?? 0;
+                              return (
+                                <div key={`${p.marketId}-${addrLower}`} className="border border-[#1E4775]/20 p-3">
+                                  <div className="flex items-start justify-between gap-3">
+                                    <label className="flex items-start gap-3 cursor-pointer">
+                                      <input
+                                        type="checkbox"
+                                        checked={isSelected}
+                                        onChange={() => togglePool(addrLower)}
+                                        className="mt-1"
+                                      />
+                                      <div className="min-w-0">
+                                        <div className="font-semibold text-[#1E4775] flex flex-wrap items-center gap-x-2">
+                                          <span>
+                                            {selectedTokenOption.symbol} ({p.collateralSymbol}) {p.poolType} pool
+                                          </span>
+                                          <span className="text-xs font-semibold text-[#1E4775]/70">
+                                            APR: {p.apr !== undefined ? `${p.apr.toFixed(2)}%` : "—"}({p.marketId})
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </label>
+
+                                    {showPct && (
+                                      <div className="flex items-center gap-2">
+                                        <input
+                                          type="number"
+                                          min={0}
+                                          max={100}
+                                          value={pct}
+                                          onChange={(e) =>
+                                            setPoolPct(addrLower, Number(e.target.value))
+                                          }
+                                          className="w-20 px-2 py-1 border border-[#1E4775]/30 text-[#1E4775] text-sm"
+                                        />
+                                        <span className="text-sm text-[#1E4775]/70">%</span>
+                                      </div>
+                                    )}
+                                  </div>
+                                </div>
+                              );
+                            })}
+                        </div>
+                        {selectedPools.size === 0 ? (
+                          <div className="text-xs text-[#1E4775]/70">
+                            Select one or more pools to continue.
+                          </div>
+                        ) : (
+                          <div className="text-xs text-[#1E4775]/70">
+                            Total: {totalPct}%{" "}
+                            {pctError ? (
+                              <span className="text-rose-600">({pctError})</span>
+                            ) : null}
+                          </div>
+                        )}
+
+                        {/* Fee preview (required before Continue) */}
+                        {targetMarketId && selectedPools.size > 0 && !pctError && (
+                          <div className="pt-3 border-t border-[#1E4775]/15 space-y-2">
+                            <div className="flex items-center justify-between gap-3">
+                              <div className="text-xs font-semibold text-[#1E4775]/80 uppercase tracking-wide">
+                                Estimated fees (dry run)
+                              </div>
+                            </div>
+
+                            {preflight?.key !== preflightKey && (
+                              <div className="text-xs text-[#1E4775]/70">Calculating…</div>
+                            )}
+
+                            {preflight?.isLoading && (
+                              <div className="text-xs text-[#1E4775]/70">Calculating…</div>
+                            )}
+
+                            {preflight?.error && preflight.key === preflightKey && (
+                              <div className="text-xs text-rose-600">
+                                {preflight.error}
+                              </div>
+                            )}
+
+                            {preflight &&
+                            !preflight.isLoading &&
+                            !preflight.error &&
+                            preflight.key === preflightKey ? (
+                              preflight.fees.length ? (
+                                <div className="space-y-2">
+                                  {preflight.fees.map((f) => (
+                                    <div
+                                      key={f.id}
+                                      className="p-2 border border-amber-200 bg-amber-50 text-xs"
+                                    >
+                                      <div className="flex items-center justify-between gap-2">
+                                        <div className="font-semibold text-amber-900">
+                                          {f.label}
+                                        </div>
+                                        <div className="font-mono font-semibold text-amber-900">
+                                          {f.feeFormatted} {f.tokenSymbol}
+                                          {f.feePercentage !== undefined && (
+                                            <span className="text-amber-700 ml-2">
+                                              ({f.feePercentage.toFixed(2)}%)
+                                            </span>
+                                          )}
+                                        </div>
+                                      </div>
+                                      {f.details && (
+                                        <div className="text-amber-800/80 mt-1">
+                                          {f.details}
+                                        </div>
+                                      )}
+                                    </div>
+                                  ))}
+                                </div>
+                              ) : (
+                                <div className="text-xs text-[#1E4775]/70">
+                                  No protocol fees detected for your current rewards.
+                                </div>
+                              )
+                            ) : null}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </label>
+          </div>
+        </div>
+
+        <div className="flex gap-2 sm:gap-4 p-3 sm:p-4 lg:p-6 border-t border-[#1E4775]/20">
+          <button
+            onClick={onClose}
+            className="flex-1 py-2 px-4 text-[#1E4775]/70 hover:text-[#1E4775] transition-colors"
+          >
+            Back
+          </button>
+          <button
+            onClick={() =>
+              onContinue({
+                mode,
+                targetMarketId: mode === "single-token" ? targetMarketId : undefined,
+                allocations:
+                  mode === "single-token"
+                    ? allocationArray
+                    : undefined,
+              })
+            }
+          disabled={
+            (mode === "single-token" &&
+              (!canSingleToken ||
+                !targetMarketId ||
+                selectedPools.size === 0 ||
+                !!pctError ||
+                // Require fee preview before continuing in Advanced mode
+                !preflight ||
+                preflight.isLoading ||
+                !!preflight.error ||
+                preflight.key !== preflightKey)) ||
+            (mode === "keep-per-token" &&
+              (!simplePreflight ||
+                simplePreflight.isLoading ||
+                !!simplePreflight.error ||
+                simplePreflight.key !== simplePreflightKey))
+          }
+            className="flex-1 py-2 px-4 font-medium transition-colors bg-[#1E4775] hover:bg-[#17395F] text-white disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed"
+          >
+            Continue
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+

--- a/src/components/GenesisShareModal.tsx
+++ b/src/components/GenesisShareModal.tsx
@@ -38,7 +38,7 @@ https://www.harborfinance.io/`;
  />
 
  {/* Modal */}
-        <div className="relative bg-white shadow-2xl w-full max-w-md mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 overflow-hidden rounded-lg max-h-[95vh] sm:max-h-[90vh] overflow-y-auto">
+        <div className="relative bg-white shadow-2xl w-full max-w-md mx-2 sm:mx-4 animate-in fade-in-0 scale-in-95 duration-200 overflow-hidden rounded-none max-h-[95vh] sm:max-h-[90vh] overflow-y-auto">
  {/* Decorative header wave */}
  <div className="absolute top-0 left-0 right-0 h-32 bg-gradient-to-br from-[#1E4775] via-[#2A5A8C] to-[#17395F]">
  <div className="absolute bottom-0 left-0 right-0">

--- a/src/components/TideAPRTooltip.tsx
+++ b/src/components/TideAPRTooltip.tsx
@@ -210,7 +210,7 @@ export default function TideAPRTooltip({
         <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/50">
           <div
             id="fdv-modal"
-            className="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-2xl"
+            className="bg-white rounded-none p-6 max-w-md w-full mx-4 shadow-2xl"
           >
             <div className="flex justify-between items-center mb-4">
               <h3 className="text-lg font-semibold text-[#1E4775]">


### PR DESCRIPTION
Users can have both collateral + sail pool deposits (and across multiple markets that share a ha token). We were collapsing these into a single aggregated row, which hid positions.

## Changes
- Anchor page expanded group view: show one row per (marketId, poolType) for stability pool positions.
- Withdraw modal (grouped markets): add a per-market position selector so users can pick the correct pool + market.

## QA
- With haBTC deposits in both collateral and sail pools, both now appear.
- Withdraw flow can target the correct pool position.