### PR TITLE
fix: dashboard MV filtering uses genesisActive config

### DIFF
--- a/src/hooks/useDashboardPositions.ts
+++ b/src/hooks/useDashboardPositions.ts
@@ -6,8 +6,7 @@ import { useMemo } from "react";
 import { getGraphUrl, getGraphHeaders, getSailPriceGraphUrlOptional } from "@/config/graph";
 import { useAnchorLedgerMarks } from "@/hooks/useAnchorLedgerMarks";
 import { buildDashboardAddressIndex } from "@/utils/dashboardPositionLabels";
-import { markets } from "@/config/markets";
-import { isMegaethMaidenVoyageMarket } from "@/utils/megaethMarket";
+import { markets, isGenesisHiddenFromIndex } from "@/config/markets";
 
 const USD_EPS = 0.005;
 
@@ -66,7 +65,7 @@ export function useDashboardPositions() {
         const g = (mkt as { addresses?: { genesis?: string } }).addresses?.genesis;
         if (!g || g === "0x0000000000000000000000000000000000000000") return false;
         if ((mkt as { status?: string }).status === "coming-soon") return false;
-        if (isMegaethMaidenVoyageMarket(id, mkt)) return false;
+        if (isGenesisHiddenFromIndex(mkt)) return false;
         return true;
       })
       .map(([_, mkt]) =>

--- a/src/utils/dashboardPositionLabels.ts
+++ b/src/utils/dashboardPositionLabels.ts
@@ -1,5 +1,4 @@
-import { markets } from "@/config/markets";
-import { isMegaethMaidenVoyageMarket } from "@/utils/megaethMarket";
+import { markets, isGenesisHiddenFromIndex } from "@/config/markets";
 
 export type DashboardMarketRef = {
   marketId: string;
@@ -7,7 +6,7 @@ export type DashboardMarketRef = {
 };
 
 export type DashboardGenesisRef = DashboardMarketRef & {
-  /** When true, omit from Maiden Voyage dashboard lists (MegaETH parity with genesis index). */
+  /** When true, omit from Maiden Voyage dashboard lists (`genesisActive: false`). */
   hideFromMvList: boolean;
 };
 
@@ -46,7 +45,7 @@ export function buildDashboardAddressIndex(): {
     if (g && g !== "0x0000000000000000000000000000000000000000") {
       genesisByAddressLower.set(g, {
         ...ref,
-        hideFromMvList: isMegaethMaidenVoyageMarket(marketId, m),
+        hideFromMvList: isGenesisHiddenFromIndex(m),
       });
     }
 


### PR DESCRIPTION
Replace removed megaethMarket helper with isGenesisHiddenFromIndex so production builds match genesis index visibility.